### PR TITLE
fix: state not saving to disk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ REDIS_PERSONAL_NS=<your-name>
 
 # The network to use, currently Vana Satori testnet
 OD_CHAIN_NETWORK=satori
-OD_CHAIN_NETWORK_ENDPOINT=http://rpc.satori.vana.org
+OD_CHAIN_NETWORK_ENDPOINT=https://rpc.satori.vana.org
 
 # Optional: OpenAI API key for additional data quality check
 OPENAI_API_KEY="sk-nXXXXX"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ base64 -i private_key.asc > private_key_base64.asc
 The Vana command line interface (`vanacli`) is the primary command line tool for interacting with the Vana network.
 It can be used to deploy nodes, manage wallets, stake/unstake, nominate, transfer tokens, and more.
 
-### Setup vanacli
+### (Optional) Setup vanacli
+To install vanacli system-wide, run the following command:
 
 ```shell
 pip install vana

--- a/chatgpt/nodes/base_node.py
+++ b/chatgpt/nodes/base_node.py
@@ -155,7 +155,7 @@ class BaseNode(ABC):
         # Ensure validator hotkey is still registered on the network.
         self.check_registered()
 
-        if self.should_sync_state():
+        if current_block % self.config.node.epoch_length == 0:
             self.resync_state()
             self.state.save()
 
@@ -186,12 +186,6 @@ class BaseNode(ABC):
             )
             # Do not exit, registration status can change
             # exit()
-
-    def should_sync_state(self):
-        """
-        Check if enough epoch blocks have elapsed since the last checkpoint to sync.
-        """
-        return (self.block - self.state.last_update) > self.config.node.epoch_length
 
     @staticmethod
     def determine_dlp_contract(network: str):

--- a/chatgpt/utils/misc.py
+++ b/chatgpt/utils/misc.py
@@ -86,8 +86,8 @@ def _ttl_hash_gen(seconds: int):
         yield floor((time.time() - start_time) / seconds)
 
 
-# 12 seconds updating block.
-@ttl_cache(maxsize=1, ttl=12)
+# New blocks are mined every 6 seconds
+@ttl_cache(maxsize=1, ttl=6)
 def ttl_get_block(self) -> int:
     """
     Retrieves the current block number from the blockchain. This method is cached with a time-to-live (TTL)

--- a/docs/running_on_testnet.md
+++ b/docs/running_on_testnet.md
@@ -35,7 +35,8 @@ poetry install
 
 Configure the environment variables by copying and modifying the `.env.example` file, to a `.env` file in the root of the project. 
 
-## Setup vanacli
+## (Optional) Setup vanacli
+To install vanacli system-wide, run the following command:
 
 ```shell
 pip install vana
@@ -81,7 +82,7 @@ First, fund your metamask or other evm-compatible wallet from the faucet so you 
 Add the Satori Testnet to your metamask wallet: 
 ```bash
 Network name: Satori Testnet
-RPC URL: http://rpc.satori.vana.org
+RPC URL: https://rpc.satori.vana.org
 Chain ID: 14801
 Currency: DAT
 ```
@@ -116,7 +117,7 @@ Copy the address and private key over to the .env file:
 ```.env
 DEPLOYER_PRIVATE_KEY=0x8...7
 OWNER_ADDRESS=0x3....1
-SATORI_RPC_URL=http://rpc.satori.vana.org
+SATORI_RPC_URL=https://rpc.satori.vana.org
 ```
 
 5. Deploy DataLiquidityPool and Token smart contracts. Make a note of 1. the DLP contract address and 2. the token contract address.


### PR DESCRIPTION
This addresses a few bugfixes, primarily regarding the state not being saved to disk. 
- caching current block number for too long (12 seconds before, which made it so that a block was skipped)
- minor doc updates